### PR TITLE
Add support for customizing the VPN profile name

### DIFF
--- a/bin/ovpnmcgen.rb
+++ b/bin/ovpnmcgen.rb
@@ -34,6 +34,7 @@ command :generate do |c|
   c.option '--v12compat', 'Enable OpenVPN Connect 1.2.x compatibility. When Enabled, use updated `VPNSubType: net.openvpn.connect.app` (changed since OpenVPN Connect 1.2.x). [Default: Disabled]'
   c.option '--security-level LEVEL', 'Security level of VPN-On-Demand Behaviour: paranoid, high, medium. [Default: high]'
   c.option '--vpn-uuid UUID', 'Override a VPN configuration payload UUID.'
+  c.option '--vpn-name NAME', 'Override a VPN configuration payload name displayed under Settings.app > General > VPN.'
   c.option '--profile-uuid UUID', 'Override a Profile UUID.'
   c.option '--cert-uuid UUID', 'Override a Certificate payload UUID.'
   c.option '-t', '--trusted-ssids SSIDS', Array, 'List of comma-separated trusted SSIDs.'
@@ -90,6 +91,7 @@ command :generate do |c|
       :untrusted_ssids => options.untrusted_ssids || config.untrusted_ssids,
       :profile_uuid => options.profile_uuid || config.profile_uuid,
       :vpn_uuid => options.vpn_uuid || config.vpn_uuid,
+      :vpn_name => options.vpn_name || config.vpn_name,
       :cert_uuid => options.cert_uuid || config.cert_uuid,
       :security_level => options.security_level
     }

--- a/features/gen_basic.feature
+++ b/features/gen_basic.feature
@@ -444,3 +444,11 @@ Feature: Basic Generate Functionality
 			\s*</dict>
 			\s*</array>
 			"""
+
+	Scenario: The VPN profile name flag is set.
+		When I run `ovpnmcgen.rb g --host aruba.cucumber.org --cafile ca.crt --p12file p12file.p12 --vpn-name foobar cucumber aruba`
+		Then the output should match:
+			"""
+			<key>UserDefinedName</key>
+			\s*<string>foobar</string>
+			"""

--- a/lib/ovpnmcgen.rb
+++ b/lib/ovpnmcgen.rb
@@ -19,6 +19,7 @@ module Ovpnmcgen
     untrusted_ssids = inputs[:untrusted_ssids] || false
     remotes = inputs[:remotes] || false
     vodDomains = inputs[:domains] || false
+    vpnName = inputs[:vpn_name] || "#{host}/VoD"
 
     # Ensure [un]trusted_ssids are Arrays.
     trusted_ssids = Array(trusted_ssids) if trusted_ssids
@@ -173,7 +174,7 @@ module Ovpnmcgen
       'PayloadType' => 'com.apple.vpn.managed',
       'PayloadUUID' => vpnUUID,
       'PayloadVersion' => 1,
-      'UserDefinedName' => "#{host}/VoD",
+      'UserDefinedName' => vpnName,
       'VPN' => {
         'AuthenticationMethod' => 'Certificate',
         'OnDemandEnabled' => (enableVOD)? 1 : 0,


### PR DESCRIPTION
When loading multiple profiles using this tool, it becomes complicated to distinguish between different profiles as they all have the same name.

This PR adds a command line argument to support customizing the profile name displayed under `Settings.app > General > VPN`.