### PR TITLE
Add support for disconnect on idle timer

### DIFF
--- a/bin/ovpnmcgen.rb
+++ b/bin/ovpnmcgen.rb
@@ -42,6 +42,7 @@ command :generate do |c|
   c.option '--domain-probe-url PROBE', String, 'An HTTP(S) URL to probe, using a GET request. If no HTTP response code is received from the server, a VPN connection is established in response.'
   c.option '--url-probe URL', 'This URL must return HTTP status 200, without redirection, before the VPN service will try establishing.'
   c.option '--remotes REMOTES', Array, 'List of comma-separated alternate remotes: "<host> <port> <proto>".'
+  c.option '--idle-timer TIME', Integer, 'Disconnect from VPN when idle for a certain period of time (in seconds) which is useful for VPN-On-Demand scenarios. Requires disabling "Reconnect On Wakeup" on OpenVPN.app.'
   c.option '--ovpnconfigfile FILE', 'Path to OpenVPN client config file.'
   c.option '-o', '--output FILE', 'Output to file. [Default: stdout]'
   c.action do |args, options|
@@ -103,6 +104,7 @@ command :generate do |c|
     inputs[:domains] = options.domains || config.domains if options.domains or config.domains
     inputs[:domain_probe_url] = options.domain_probe_url || config.domain_probe_url if options.domain_probe_url or config.domain_probe_url
     inputs[:v12compat] = options.v12compat || config.v12compat if options.v12compat or config.v12compat
+    inputs[:idle_timer] = options.idle_timer || config.idle_timer if options.idle_timer or config.idle_timer
 
     unless options.output
       puts Ovpnmcgen.generate(inputs)

--- a/features/gen_basic.feature
+++ b/features/gen_basic.feature
@@ -444,3 +444,13 @@ Feature: Basic Generate Functionality
 			\s*</dict>
 			\s*</array>
 			"""
+
+	Scenario: The idle timer flag is set.
+		When I run `ovpnmcgen.rb g --host aruba.cucumber.org --cafile ca.crt --p12file p12file.p12 --idle-timer 10 cucumber aruba`
+		Then the output should match:
+			"""
+			<key>DisconnectOnIdle</key>
+			\s*<integer>1</integer>
+			\s*<key>DisconnectOnIdleTimer</key>
+			\s*<integer>10</integer>
+			"""

--- a/lib/ovpnmcgen.rb
+++ b/lib/ovpnmcgen.rb
@@ -190,6 +190,10 @@ module Ovpnmcgen
       vpn['VPN']['AuthenticationMethod'] = 'Password'
       vpn['VPN'].delete('PayloadCertificateUUID')
     end
+    if inputs[:idle_timer]
+      vpn['VPN']['DisconnectOnIdle'] = 1
+      vpn['VPN']['DisconnectOnIdleTimer'] = inputs[:idle_timer]
+    end
 
     plistPayloadContent = [vpn]
     plistPayloadContent << cert if p12file


### PR DESCRIPTION
Disconnect on idle allows the VPN to be shut down if the connection isn't active for a certain amount of time.

May require additional server side tuning and disabling "Require on Wakeup" under OpenVPN.app. 