### PR TITLE
Extract user and device information from p12

### DIFF
--- a/bin/ovpnmcgen.rb
+++ b/bin/ovpnmcgen.rb
@@ -45,8 +45,6 @@ command :generate do |c|
   c.option '--ovpnconfigfile FILE', 'Path to OpenVPN client config file.'
   c.option '-o', '--output FILE', 'Output to file. [Default: stdout]'
   c.action do |args, options|
-    raise ArgumentError.new "Invalid arguments. Run '#{File.basename(__FILE__)} help generate' for guidance" if args.nil? or args.length < 2
-
     # Set up configuration environment.
     if options.config
       Ovpnmcgen.configure(options.config)
@@ -54,6 +52,16 @@ command :generate do |c|
       Ovpnmcgen.configure
     end
     config = Ovpnmcgen.config
+
+    user, device = args
+    if args.empty? and (options.p12file or config.p12file)
+      filename = File.basename((options.p12file or config.p12file), '.p12')
+      user, device = filename.split('-') if filename
+    end
+
+    unless user and device
+      raise ArgumentError.new "Invalid arguments. Run '#{File.basename(__FILE__)} help generate' for guidance"
+    end
 
     raise ArgumentError.new "Host is required" unless options.host or config.host
     raise ArgumentError.new "cafile is required" unless options.cafile or config.cafile
@@ -74,8 +82,6 @@ command :generate do |c|
       :proto => (config.proto)? config.proto : 'udp',
       :port => (config.port)? config.port : 1194,
       :security_level => (config.security_level)? config.security_level : 'high'
-
-    user, device = args
 
     inputs = {
       :user => user,

--- a/features/gen_basic.feature
+++ b/features/gen_basic.feature
@@ -16,6 +16,11 @@ Feature: Basic Generate Functionality
 			p12file that should appear
 			In base64 encoding as <data/>
 			"""
+		And a file named "cucumber-aruba.p12" with:
+			"""
+			p12file with filename that matches
+			#{user}-#{device} pattern
+			"""
 		And a file named "cert.crt" with:
 			"""
 			Contents of cert file
@@ -108,6 +113,18 @@ Feature: Basic Generate Functionality
 			<key>OnDemandEnabled</key>
 			\s*<integer>1</integer>
 			"""
+
+	Scenario: Correct arguments with all required flags, host, cafile, and p12file (no cert and key) in #{user}-#{device} pattern.
+		When I run `ovpnmcgen.rb g --host aruba.cucumber.org --cafile ca.crt --p12file cucumber-aruba.p12`
+		Then the output should match:
+		"""
+		<key>PayloadDescription</key>
+		\s*<string>OpenVPN Configuration Payload for cucumber-aruba@aruba.cucumber.org</string>
+		\s*<key>PayloadDisplayName</key>
+		\s*<string>aruba.cucumber.org OpenVPN cucumber@aruba</string>
+		\s*<key>PayloadIdentifier</key>
+		\s*<string>org.cucumber.aruba.cucumber-aruba</string>
+		"""
 
 	@OCv1.2 @v0.6.0
 	Scenario: Correct arguments with all required flags, host, cafile, cert, and key (no p12file).


### PR DESCRIPTION
If p12 profile filename follows the `{user}-{device}.p12` pattern and no arguments have been passed to the cli, assume extracted values.

This enabled unattended *.yml file parsing as no requirements need to be set in order to process a large number of config files.