### PR TITLE
Make profile uuid stable

### DIFF
--- a/features/gen_basic.feature
+++ b/features/gen_basic.feature
@@ -444,3 +444,11 @@ Feature: Basic Generate Functionality
 			\s*</dict>
 			\s*</array>
 			"""
+
+	Scenario: The profile UUID flag is set.
+		When I run `ovpnmcgen.rb g --host aruba.cucumber.org --cafile ca.crt --p12file p12file.p12 --profile-uuid A43E7B13-4F02-4121-9B70-81C734E495C1 cucumber aruba`
+		Then the output should match:
+			"""
+			<key>PayloadIdentifier</key>
+			\s*<string>com.apple.vpn.managed.A43E7B13-4F02-4121-9B70-81C734E495C1</string>
+			"""

--- a/lib/ovpnmcgen.rb
+++ b/lib/ovpnmcgen.rb
@@ -196,9 +196,9 @@ module Ovpnmcgen
     #encPlistPayloadContent = cmsEncrypt([vpn, cert].to_plist).der_format
 
     plist = {
-      'PayloadDescription' => "OpenVPN Configuration Payload for #{user}-#{device}@#{host}",
+      'PayloadDescription' => plistDescription,
       'PayloadDisplayName' => "#{host} OpenVPN #{user}@#{device}",
-      'PayloadIdentifier' => "#{identifier}.#{user}-#{device}",
+      'PayloadIdentifier' => (inputs[:profile_uuid]) ? "com.apple.vpn.managed.#{plistUUID}" : "#{identifier}.#{user}-#{device}",
       'PayloadOrganization' => domain,
       'PayloadRemovalDisallowed' => false,
       'PayloadType' => 'Configuration',


### PR DESCRIPTION
Having stable `PayloadIdentifier`s allows having multiple profiles for the same user and device working properly without overriding each other. This can be useful in a scenario where a profile may be used for automatic/split traffic and another one to route all traffic to the VPN gateway.

This is also Apple's recommended guidelines for payload identifiers.