### PR TITLE
Improve profile description with VPN config map

### DIFF
--- a/lib/ovpnmcgen.rb
+++ b/lib/ovpnmcgen.rb
@@ -19,6 +19,7 @@ module Ovpnmcgen
     untrusted_ssids = inputs[:untrusted_ssids] || false
     remotes = inputs[:remotes] || false
     vodDomains = inputs[:domains] || false
+    plistDescription = "OpenVPN Configuration Payload for #{user}-#{device}@#{host}"
 
     # Ensure [un]trusted_ssids are Arrays.
     trusted_ssids = Array(trusted_ssids) if trusted_ssids
@@ -63,6 +64,7 @@ module Ovpnmcgen
 
     unless inputs[:ovpnconfigfile].nil?
       ovpnconfighash = Ovpnmcgen.getOVPNVendorConfigHash(inputs[:ovpnconfigfile])
+      plistDescription = "#{plistDescription}. Includes custom OpenVPN directives #{ovpnconfighash.to_s.gsub('"', '').gsub('=>', '=')}."
     else # Bare minimum configuration
       ovpnconfighash = {
         'client' => 'NOARGS',


### PR DESCRIPTION
Adds more visibility into which settings composes the profile. Since all sensitive fields are skipped, there isn't a risk of leaking undesired information.