### PR TITLE
Improve url probe handling

### DIFF
--- a/bin/ovpnmcgen.rb
+++ b/bin/ovpnmcgen.rb
@@ -40,6 +40,7 @@ command :generate do |c|
   c.option '-u', '--untrusted-ssids SSIDS', Array, 'List of comma-separated untrusted SSIDs.'
   c.option '-d', '--domains DOMAINS', Array, 'List of comma-separated domain names requiring VPN service.'
   c.option '--domain-probe-url PROBE', String, 'An HTTP(S) URL to probe, using a GET request. If no HTTP response code is received from the server, a VPN connection is established in response.'
+  c.option '--trusted-ssids-probe-url PROBE', String, 'An HTTP(S) URL to probe, using a GET request. If no HTTP response code is received from the server, a VPN connection may be established in response.'
   c.option '--url-probe URL', 'This URL must return HTTP status 200, without redirection, before the VPN service will try establishing.'
   c.option '--remotes REMOTES', Array, 'List of comma-separated alternate remotes: "<host> <port> <proto>".'
   c.option '--ovpnconfigfile FILE', 'Path to OpenVPN client config file.'
@@ -61,6 +62,10 @@ command :generate do |c|
     # A --p12file or (--cert and --key) needs to be provided. Shall not prevent user from specifying both.
     unless (options.p12file or config.p12file) or ((options.cert or config.cert) and (options.key or config.key))
       raise ArgumentError.new "PKCS#12 or cert & key file required"
+    end
+
+    if (options.trusted_ssids_probe_url or config.trusted_ssids_probe_url) and not (options.trusted_ssids or config.trusted_ssids)
+      raise ArgumentError.new "cannot set --trusted-ssids-probe-url without --trusted-ssids"
     end
 
     options.default :vod => case
@@ -87,6 +92,7 @@ command :generate do |c|
       :port => options.port,
       :enableVOD => options.vod,
       :trusted_ssids => options.trusted_ssids || config.trusted_ssids,
+      :trusted_ssids_probe_url => options.trusted_ssids_probe_url || config.trusted_ssids_probe_url,
       :untrusted_ssids => options.untrusted_ssids || config.untrusted_ssids,
       :profile_uuid => options.profile_uuid || config.profile_uuid,
       :vpn_uuid => options.vpn_uuid || config.vpn_uuid,

--- a/features/gen_basic.feature
+++ b/features/gen_basic.feature
@@ -284,6 +284,25 @@ Feature: Basic Generate Functionality
 			\s*</array>
 			"""
 
+	Scenario: The trusted ssids flag is set and trusted ssids probe URL is set.
+		When I run `ovpnmcgen.rb g --host aruba.cucumber.org --cafile ca.crt --p12file p12file.p12 --trusted-ssids trusted1 --trusted-ssids-probe-url "https://example.com/200.html" cucumber aruba`
+		Then the output should match:
+			"""
+			<string>Disconnect</string>
+			\s*<key>InterfaceTypeMatch</key>
+			\s*<string>WiFi</string>
+			\s*<key>SSIDMatch</key>
+			\s*<array>
+			\s*<string>trusted1</string>
+			\s*</array>
+			\s*<key>URLStringProbe</key>
+			\s*<string>https:\/\/example\.com\/200\.html</string>
+			"""
+
+	Scenario: The trusted ssids probe URL is set without trusted ssids flag being set.
+		When I run `ovpnmcgen.rb g --host aruba.cucumber.org --cafile ca.crt --p12file p12file.p12 --trusted-ssids-probe-url "https://example.com/200.html" cucumber aruba`
+		Then the output should contain "error: cannot set --trusted-ssids-probe-url without --trusted-ssids"
+
 	Scenario: The security-level flag is set to paranoid.
 		When I run `ovpnmcgen.rb g --host aruba.cucumber.org --cafile ca.crt --p12file p12file.p12 --security-level paranoid cucumber aruba`
 		Then the output should match:

--- a/lib/ovpnmcgen.rb
+++ b/lib/ovpnmcgen.rb
@@ -134,7 +134,7 @@ module Ovpnmcgen
       'Action' => 'Ignore'
     }
 
-    # Insert URLStringProbe conditions when enabled with --url-probe
+    # Insert URLStringProbe conditions when enabled with --url-probe.
     vodTrusted['URLStringProbe'] =
       vodUntrusted['URLStringProbe'] =
       vodWifiOnly['URLStringProbe'] =
@@ -142,6 +142,9 @@ module Ovpnmcgen
       vodCellularOnly['URLStringProbe'] =
       vodDefault['URLStringProbe'] =
       inputs[:url_probe] if inputs[:url_probe]
+
+    # Insert trusted SSIDs-specific URLStringProbe condition when enabled with --trusted-ssids-url-probe.
+    vodTrusted['URLStringProbe'] = inputs[:trusted_ssids_probe_url] if inputs[:trusted_ssids_probe_url]
 
     vpnOnDemandRules << vodTrusted if trusted_ssids
     vpnOnDemandRules << vodUntrusted if untrusted_ssids


### PR DESCRIPTION
I am not entirely sure what use adding the URL probe to all interfaces is trying to solve, but I assume always-on VPNs where the endpoint of the probe is public (to some degree, any URL without redirection would work, such as Apple's captive test one).

The use case I have added support for is a bit different: when a trusted WiFi SSID is set, iOS automatically disconnects the VPN as soon as the interface changes to WiFi. The problem is there might be other networks with the same SSID which obviously won't route the traffic, but there is also the possibility of the routing being somehow misconfigured and temporarily not serving traffic as expected.

Introducing a URL probe for trusted SSIDs enables iOS to probe that URL for reachability before assuming it can immediately disconnect just because the SSID is trusted.