### PR TITLE
Do not disconnect from VPN over cellular if security level is medium

### DIFF
--- a/features/gen_basic.feature
+++ b/features/gen_basic.feature
@@ -378,7 +378,7 @@ Feature: Basic Generate Functionality
 		And the output should match:
 			"""
 			<key>Action</key>
-			\s*<string>Disconnect</string>
+			\s*<string>Ignore</string>
 			\s*<key>InterfaceTypeMatch</key>
 			\s*<string>Cellular</string>
 			"""

--- a/lib/ovpnmcgen.rb
+++ b/lib/ovpnmcgen.rb
@@ -133,14 +133,14 @@ module Ovpnmcgen
     vodCellularOnly = { # Trust Cellular
       'InterfaceTypeMatch' => 'Cellular',
       'Action' => case inputs[:security_level]
-          when 'paranoid'
-            'Connect'
-          when 'high'
-            'Ignore'
-          else # medium
-            'Disconnect'
-          end
+        when 'paranoid'
+          'Connect'
+        else # high, medium
+          'Ignore'
+        end
     }
+
+    # Default catch-all to prevent circular race.
     vodDefault = { # Default catch-all
       'Action' => 'Ignore'
     }


### PR DESCRIPTION
I believe this was done in mistake as I don't see a reason for disconnecting over cellular when the security level is medium or higher. At least I would say it's safer if we simply ignore the directive.